### PR TITLE
Set extension as homepage in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,9 @@
   },
   "chrome_url_overrides": {
     "newtab": "index.html"
+  },
+  "chrome_settings_overrides": {
+    "homepage": "index.html"
   }
 }
 


### PR DESCRIPTION
Hi, I installed the firefox extension and I really like it!

I noticed that it is not treated as homepage, though (nothing happens when you click the "home" icon in the firefox toolbar).
This should fix it.

Cheers.